### PR TITLE
Bump version to 1.0.1 to restart npm flow

### DIFF
--- a/packages/moltbrowser-mcp/package.json
+++ b/packages/moltbrowser-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moltbrowser-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Playwright MCP with WebMCP Hub integration — dynamic, per-site tools for browser agents",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bumps package version from 1.0.0 to 1.0.1 to bypass npm's 24h republish lock after the previous unpublish