### PR TITLE
Fix npx bin entry for moltbrowser-mcp-server

### DIFF
--- a/packages/moltbrowser-mcp/package.json
+++ b/packages/moltbrowser-mcp/package.json
@@ -47,6 +47,7 @@
   },
   "bin": {
     "playwright-mcp": "cli.js",
-    "moltbrowser-mcp": "hub-cli.js"
+    "moltbrowser-mcp": "hub-cli.js",
+    "moltbrowser-mcp-server": "hub-cli.js"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `moltbrowser-mcp-server` bin entry pointing to `hub-cli.js` so `npx moltbrowser-mcp-server` resolves correctly
- Without this, npx fails with "could not determine executable to run" because no bin name matches the package name

## Test plan
- [ ] Run `npx moltbrowser-mcp-server` and verify it starts the hub proxy server