### PR TITLE
Bump version to 1.0.1 for republish

### DIFF
--- a/packages/moltbrowser-mcp/package.json
+++ b/packages/moltbrowser-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moltbrowser-mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Playwright MCP with WebMCP Hub integration — dynamic, per-site tools for browser agents",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bumps version from 1.0.0 to 1.0.1 so npm publish succeeds (1.0.0 is already published)

## Test plan
- [ ] Merge and verify npm publish CI succeeds
- [ ] Run `npx moltbrowser-mcp-server` and confirm it starts