### PR TITLE
Fix npx command in hub-cli.js comment

### DIFF
--- a/packages/moltbrowser-mcp/hub-cli.js
+++ b/packages/moltbrowser-mcp/hub-cli.js
@@ -6,7 +6,7 @@
  * with WebMCP Hub integration for dynamic, per-site tools.
  *
  * Usage:
- *   npx moltbrowser-mcp [options]
+ *   npx moltbrowser-mcp-server [options]
  *
  * Hub options:
  *   --hub-url=<url>        Override hub URL (default: https://webmcp-hub.com)


### PR DESCRIPTION
## Summary
- Updates the usage comment in `hub-cli.js` from `npx moltbrowser-mcp` to `npx moltbrowser-mcp-server` to match the actual package name

## Test plan
- [ ] Verify comment accuracy