### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-04
+
+### Improved
+- Browser tool reliability with schema hints and Shadow DOM fallbacks
+- Updated README references to `moltbrowser-mcp-server` and added config dropdown
+
 ## [1.0.0] - 2026-03-03
 
 ### Added

--- a/packages/moltbrowser-mcp/package.json
+++ b/packages/moltbrowser-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moltbrowser-mcp-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Playwright MCP with WebMCP Hub integration — dynamic, per-site tools for browser agents",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bumps `moltbrowser-mcp-server` version from 1.0.1 to 1.1.0
- Updates CHANGELOG with 1.1.0 entry (schema hints, Shadow DOM fallbacks, README improvements)

## Test plan
- [ ] Verify `package.json` version is `1.1.0`
- [ ] Verify CHANGELOG.md has correct 1.1.0 entry
- [ ] Run `npm publish` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)