### PR TITLE
Increase CI test timeout to 60s

### DIFF
--- a/packages/moltbrowser-mcp/playwright.config.ts
+++ b/packages/moltbrowser-mcp/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig<TestOptions>({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
+  timeout: process.env.CI ? 60_000 : 30_000,
   workers: process.env.CI ? 2 : undefined,
   reporter: 'list',
   projects: [


### PR DESCRIPTION
The browser_click test timed out at 30.1s on CI due to MCP server + browser cold start overhead. Bump to 60s in CI only.