### PR TITLE
Rename repo URLs from moltbrowser-mcp to moltbrowser

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -33,7 +33,7 @@ Examples of unacceptable behavior:
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by opening a [private security advisory](https://github.com/Joakim-Sael/moltbrowser-mcp/security/advisories/new)
+reported by opening a [private security advisory](https://github.com/Joakim-Sael/moltbrowser/security/advisories/new)
 or contacting the maintainer directly. All complaints will be reviewed and
 investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ packages/
 Clone the repo and install dependencies:
 
 ```bash
-git clone https://github.com/Joakim-Sael/moltbrowser-mcp.git
+git clone https://github.com/Joakim-Sael/moltbrowser.git
 cd moltbrowser-mcp
 npm ci
 ```
@@ -52,7 +52,7 @@ Good areas to contribute:
 - **Test coverage** — tests for hub proxy logic, tool registration/deregistration on navigation
 - **Bug fixes** — anything in the issue tracker
 
-Please [open an issue](https://github.com/Joakim-Sael/moltbrowser-mcp/issues) before starting work on a significant change. This helps avoid duplicate effort and makes for a smoother review.
+Please [open an issue](https://github.com/Joakim-Sael/moltbrowser/issues) before starting work on a significant change. This helps avoid duplicate effort and makes for a smoother review.
 
 ## Commit messages
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *A community-driven contribution space where agents and the humans behind them share browser configs so every agent navigates the web faster and cheaper than the last.*
 
-[![CI](https://github.com/Joakim-Sael/moltbrowser-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Joakim-Sael/moltbrowser-mcp/actions/workflows/ci.yml)
+[![CI](https://github.com/Joakim-Sael/moltbrowser/actions/workflows/ci.yml/badge.svg)](https://github.com/Joakim-Sael/moltbrowser/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/moltbrowser-mcp-server)](https://www.npmjs.com/package/moltbrowser-mcp-server)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please do not report security vulnerabilities through public GitHub issues.
 
-Instead, use [GitHub's private vulnerability reporting](https://github.com/Joakim-Sael/moltbrowser-mcp/security/advisories/new) to submit a report confidentially.
+Instead, use [GitHub's private vulnerability reporting](https://github.com/Joakim-Sael/moltbrowser/security/advisories/new) to submit a report confidentially.
 
 When reporting, please include:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Joakim-Sael/moltbrowser-mcp.git"
+    "url": "git+https://github.com/Joakim-Sael/moltbrowser.git"
   },
   "homepage": "https://webmcp-hub.com",
   "author": {

--- a/packages/moltbrowser-cli/package.json
+++ b/packages/moltbrowser-cli/package.json
@@ -4,7 +4,7 @@
   "description": "Browser automation CLI with WebMCP Hub integration — per-site tools for coding agents",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Joakim-Sael/moltbrowser-mcp.git"
+    "url": "git+https://github.com/Joakim-Sael/moltbrowser.git"
   },
   "homepage": "https://webmcp-hub.com",
   "engines": {

--- a/packages/moltbrowser-mcp/package.json
+++ b/packages/moltbrowser-mcp/package.json
@@ -4,7 +4,7 @@
   "description": "Playwright MCP with WebMCP Hub integration — dynamic, per-site tools for browser agents",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Joakim-Sael/moltbrowser-mcp.git"
+    "url": "git+https://github.com/Joakim-Sael/moltbrowser.git"
   },
   "homepage": "https://webmcp-hub.com",
   "engines": {


### PR DESCRIPTION
## Summary

- Update all GitHub URLs in package.json, README, CONTRIBUTING, SECURITY, and CODE_OF_CONDUCT to match the renamed repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)